### PR TITLE
Feat/api spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Board
 
 - models: Post, Category, Tag, PostLike, Comment, CommentLike, SogaetingOption
+- views: PostViewSet, CommentViewSet
 
 ### Operation
 

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import include, path
 from rest_framework.routers import DefaultRouter, SimpleRouter
 
 from kkanbu.users.api.views import UserViewSet
@@ -12,4 +13,9 @@ router.register("users", UserViewSet)
 
 
 app_name = "api"
-urlpatterns = router.urls
+
+urlpatterns = [
+    path("board/", include("kkanbu.board.urls")),
+]
+
+urlpatterns += router.urls

--- a/kkanbu/board/serializers.py
+++ b/kkanbu/board/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import Post
+
+
+class PostSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Post
+        exclude = ["created", "modified"]

--- a/kkanbu/board/serializers.py
+++ b/kkanbu/board/serializers.py
@@ -1,9 +1,15 @@
 from rest_framework import serializers
 
-from .models import Post
+from .models import Comment, Post
 
 
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
-        exclude = ["created", "modified"]
+        fields = "__all__"
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = "__all__"

--- a/kkanbu/board/urls.py
+++ b/kkanbu/board/urls.py
@@ -1,8 +1,9 @@
 from rest_framework.routers import DefaultRouter
 
-from .views import PostViewSet
+from .views import CommentViewSet, PostViewSet
 
 router = DefaultRouter()
 router.register(r"post", PostViewSet)
+router.register(r"comment", CommentViewSet)
 
 urlpatterns = router.urls

--- a/kkanbu/board/urls.py
+++ b/kkanbu/board/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import PostViewSet
+
+router = DefaultRouter()
+router.register(r"post", PostViewSet)
+
+urlpatterns = router.urls

--- a/kkanbu/board/views.py
+++ b/kkanbu/board/views.py
@@ -1,0 +1,17 @@
+import logging
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+
+from .models import Post
+from .serializers import PostSerializer
+
+logger = logging.getLogger(__name__)
+
+
+@extend_schema(
+    tags=["POST"],
+)
+class PostViewSet(viewsets.ModelViewSet):
+    queryset = Post.objects.all()
+    serializer_class = PostSerializer

--- a/kkanbu/board/views.py
+++ b/kkanbu/board/views.py
@@ -3,15 +3,23 @@ import logging
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 
-from .models import Post
+from .models import Comment, Post
 from .serializers import PostSerializer
 
 logger = logging.getLogger(__name__)
 
 
 @extend_schema(
-    tags=["POST"],
+    tags=["post"],
 )
 class PostViewSet(viewsets.ModelViewSet):
     queryset = Post.objects.all()
+    serializer_class = PostSerializer
+
+
+@extend_schema(
+    tags=["comment"],
+)
+class CommentViewSet(viewsets.ModelViewSet):
+    queryset = Comment.objects.all()
     serializer_class = PostSerializer


### PR DESCRIPTION
### Description

- Post, Comment ViewSet 생성
- 인증 관련 주소와 구분을 하고, cookiecutter에서 기본으로 제공된 api_router.py를 사용한 구조를 유지하기 위해 `/api/` url을 유지하기로 결정

### TOO

- 소개글을 위한 api 명세 작성

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
